### PR TITLE
Fixed win10 driver error problem ("code 10")

### DIFF
--- a/main/ble_hid/hal_ble.c
+++ b/main/ble_hid/hal_ble.c
@@ -143,6 +143,7 @@ static void hidd_event_callback(esp_hidd_cb_event_t event, esp_hidd_cb_param_t *
       break;
     case ESP_HIDD_EVENT_BLE_DISCONNECT:
       sec_conn = false;
+      hid_conn_id = -1;
       ESP_LOGI(LOG_TAG, "ESP_HIDD_EVENT_BLE_DISCONNECT");
       esp_ble_gap_start_advertising(&hidd_adv_params);
       break;

--- a/main/ble_hid/hal_ble.c
+++ b/main/ble_hid/hal_ble.c
@@ -42,6 +42,11 @@ static uint8_t hidd_service_uuid128[] = {
     0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80, 0x00, 0x10, 0x00, 0x00, 0x12, 0x18, 0x00, 0x00,
 };
 
+uint16_t getConnID()
+{
+	return hid_conn_id;
+}
+
 /** @brief Advertising data for BLE */
 static esp_ble_adv_data_t hidd_adv_data = {
     .set_scan_rsp = false,
@@ -83,7 +88,7 @@ uint8_t activateJoystick = 0;
  * This report is changed and sent on an incoming command
  * 1. byte is the modifier, bytes 2-7 are keycodes
  */
-uint8_t keyboard_report[8];
+uint8_t keyboard_report[7];
 
 
 /** @brief Currently active mouse report
@@ -178,6 +183,19 @@ static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param
           ESP_LOGE(LOG_TAG, "fail reason = 0x%x",param->ble_security.auth_cmpl.fail_reason);
       }
       break;
+      
+	case ESP_GAP_BLE_PASSKEY_NOTIF_EVT:                          /*!< passkey notification event */
+		ESP_LOGI(LOG_TAG,"ESP_GAP_BLE_PASSKEY_NOTIF_EVT: %d",param->ble_security.key_notif.passkey);
+		break;
+    case ESP_GAP_BLE_PASSKEY_REQ_EVT:                            /*!< passkey request event */
+		ESP_LOGI(LOG_TAG,"ESP_GAP_BLE_PASSKEY_REQ_EVT");
+		break;
+    case ESP_GAP_BLE_OOB_REQ_EVT:                                /*!< OOB request event */
+		ESP_LOGI(LOG_TAG,"ESP_GAP_BLE_OOB_REQ_EVT");
+		break;
+    case ESP_GAP_BLE_NC_REQ_EVT:                                 /*!< Numeric Comparison request event */
+		ESP_LOGI(LOG_TAG,"ESP_GAP_BLE_NC_REQ_EVT: %d",param->ble_security.key_notif.passkey);
+		break;
     default:
         break;
   }

--- a/main/ble_hid/hal_ble.h
+++ b/main/ble_hid/hal_ble.h
@@ -101,4 +101,6 @@ struct hid_cmd {
 };
 
 
+uint16_t getConnID();
+
 #endif /* _HAL_BLE_H_ */

--- a/main/ble_hid/hid_dev.h
+++ b/main/ble_hid/hid_dev.h
@@ -224,7 +224,7 @@ typedef uint8_t consumer_cmd_t;
                                         (s)[1] |= ((x) & 0x03) << 4
 
 // HID keyboard input report length
-#define HID_KEYBOARD_IN_RPT_LEN     8
+#define HID_KEYBOARD_IN_RPT_LEN     7
 
 // HID keyboard input report length
 #define HID_JOYSTICK_IN_RPT_LEN     12

--- a/main/ble_hid/hid_dev.h
+++ b/main/ble_hid/hid_dev.h
@@ -229,9 +229,6 @@ typedef uint8_t consumer_cmd_t;
 // HID keyboard input report length
 #define HID_JOYSTICK_IN_RPT_LEN     12
 
-// HID LED output report length
-#define HID_LED_OUT_RPT_LEN         1
-
 // HID mouse input report length
 #define HID_MOUSE_IN_RPT_LEN        5
 

--- a/main/ble_hid/hid_device_le_prf.c
+++ b/main/ble_hid/hid_device_le_prf.c
@@ -163,6 +163,50 @@ static const uint8_t hidReportMap[] = {
     0xC0,           //   End Collection
     0x81, 0x03,   //   Input (Const, Var, Abs)
     0xC0,            // End Collection
+    
+        0x05, 0x01,                     // Usage Page (Generic Desktop)
+        0x09, 0x04,                     // Usage (Joystick)
+        0xA1, 0x01,                     // Collection (Application)
+        0x85, 0x04,   // Report Id (4)
+        0x15, 0x00,                     //   Logical Minimum (0)
+        0x25, 0x01,                     //   Logical Maximum (1)
+        0x75, 0x01,                     //   Report Size (1)
+        0x95, 0x20,                     //   Report Count (32)
+        0x05, 0x09,                     //   Usage Page (Button)
+        0x19, 0x01,                     //   Usage Minimum (Button #1)
+        0x29, 0x20,                     //   Usage Maximum (Button #32)
+        0x81, 0x02,                     //   Input (variable,absolute)
+        0x15, 0x00,                     //   Logical Minimum (0)
+        0x25, 0x07,                     //   Logical Maximum (7)
+        0x35, 0x00,                     //   Physical Minimum (0)
+        0x46, 0x3B, 0x01,               //   Physical Maximum (315)
+        0x75, 0x04,                     //   Report Size (4)
+        0x95, 0x01,                     //   Report Count (1)
+        0x65, 0x14,                     //   Unit (20)
+        0x05, 0x01,                     //   Usage Page (Generic Desktop)
+        0x09, 0x39,                     //   Usage (Hat switch)
+        0x81, 0x42,                     //   Input (variable,absolute,null_state)
+        0x05, 0x01,                     //   Usage Page (Generic Desktop)
+        0x09, 0x01,                     //   Usage (Pointer)
+        0xA1, 0x00,                     //   Collection ()
+        0x15, 0x00,                     //     Logical Minimum (0)
+        0x26, 0xFF, 0x03,               //     Logical Maximum (1023)
+        0x75, 0x0A,                     //     Report Size (10)
+        0x95, 0x04,                     //     Report Count (4)
+        0x09, 0x30,                     //     Usage (X)
+        0x09, 0x31,                     //     Usage (Y)
+        0x09, 0x32,                     //     Usage (Z)
+        0x09, 0x35,                     //     Usage (Rz)
+        0x81, 0x02,                     //     Input (variable,absolute)
+        0xC0,                           //   End Collection
+        0x15, 0x00,                     //   Logical Minimum (0)
+        0x26, 0xFF, 0x03,               //   Logical Maximum (1023)
+        0x75, 0x0A,                     //   Report Size (10)
+        0x95, 0x02,                     //   Report Count (2)
+        0x09, 0x36,                     //   Usage (Slider)
+        0x09, 0x36,                     //   Usage (Slider)
+        0x81, 0x02,                     //   Input (variable,absolute)
+        0xC0,                            // End Collection
 };
 
 /// Battery Service Attributes Indexes
@@ -193,7 +237,7 @@ struct gatts_profile_inst {
 hidd_le_env_t hidd_le_env;
 
 // HID report map length
-uint8_t hidReportMapLen = sizeof(hidReportMap);
+uint16_t hidReportMapLen = sizeof(hidReportMap);
 uint8_t hidProtocolMode = HID_PROTOCOL_MODE_REPORT;
 
 // HID report mapping table
@@ -219,6 +263,10 @@ static uint8_t hidReportRefMouseIn[HID_REPORT_REF_LEN] =
 static uint8_t hidReportRefKeyIn[HID_REPORT_REF_LEN] =
              { HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT };
 
+// HID Report Reference characteristic descriptor, joystick
+static uint8_t hidReportRefJoyIn[HID_REPORT_REF_LEN] =
+             { HID_RPT_ID_JOY_IN, HID_REPORT_TYPE_INPUT };
+             
 // HID Report Reference characteristic descriptor, Feature
 static uint8_t hidReportRefFeature[HID_REPORT_REF_LEN] =
              { HID_RPT_ID_FEATURE, HID_REPORT_TYPE_FEATURE };
@@ -398,6 +446,27 @@ static esp_gatts_attr_db_t hidd_le_gatt_db[HIDD_LE_IDX_NB] =
                                                                        ESP_GATT_PERM_READ,
                                                                        sizeof(hidReportRefKeyIn), sizeof(hidReportRefKeyIn),
                                                                        hidReportRefKeyIn}},
+        // Report Characteristic Declaration
+    [HIDD_LE_IDX_REPORT_JOY_IN_CHAR]         = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid,
+                                                                         ESP_GATT_PERM_READ,
+                                                                         CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE,
+                                                                         (uint8_t *)&char_prop_read_notify}},
+    // Report Characteristic Value
+    [HIDD_LE_IDX_REPORT_JOY_IN_VAL]            = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_uuid,
+                                                                       ESP_GATT_PERM_READ,
+                                                                       HIDD_LE_REPORT_MAX_LEN, 0,
+                                                                       NULL}},
+    // Report KEY INPUT Characteristic - Client Characteristic Configuration Descriptor
+    [HIDD_LE_IDX_REPORT_JOY_IN_CCC]              = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_client_config_uuid,
+                                                                      (ESP_GATT_PERM_READ | ESP_GATT_PERM_WRITE),
+                                                                      sizeof(uint16_t), 0,
+                                                                      NULL}},
+     // Report Characteristic - Report Reference Descriptor
+    [HIDD_LE_IDX_REPORT_JOY_IN_REP_REF]       = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_ref_descr_uuid,
+                                                                       ESP_GATT_PERM_READ,
+                                                                       sizeof(hidReportRefJoyIn), sizeof(hidReportRefJoyIn),
+                                                                       hidReportRefJoyIn}},                                                                                                                                      
+                                                                       
     // Report Characteristic Declaration
     [HIDD_LE_IDX_REPORT_CC_IN_CHAR]         = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid,
                                                                          ESP_GATT_PERM_READ,
@@ -702,36 +771,43 @@ static void hid_add_id_tbl(void)
       hid_rpt_map[1].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_KEY_IN_VAL];
       hid_rpt_map[1].cccdHandle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_KEY_IN_CCC];
       hid_rpt_map[1].mode = HID_PROTOCOL_MODE_REPORT;
+      
+      // Joystick input report
+      hid_rpt_map[2].id = hidReportRefJoyIn[0];
+      hid_rpt_map[2].type = hidReportRefJoyIn[1];
+      hid_rpt_map[2].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_JOY_IN_VAL];
+      hid_rpt_map[2].cccdHandle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_JOY_IN_CCC];
+      hid_rpt_map[2].mode = HID_PROTOCOL_MODE_REPORT;
 
       // Consumer Control input report
-      hid_rpt_map[2].id = hidReportRefCCIn[0];
-      hid_rpt_map[2].type = hidReportRefCCIn[1];
-      hid_rpt_map[2].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_CC_IN_VAL];
-      hid_rpt_map[2].cccdHandle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_CC_IN_CCC];
-      hid_rpt_map[2].mode = HID_PROTOCOL_MODE_REPORT;
+      hid_rpt_map[3].id = hidReportRefCCIn[0];
+      hid_rpt_map[3].type = hidReportRefCCIn[1];
+      hid_rpt_map[3].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_CC_IN_VAL];
+      hid_rpt_map[3].cccdHandle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_CC_IN_CCC];
+      hid_rpt_map[3].mode = HID_PROTOCOL_MODE_REPORT;
 
       // Boot keyboard input report
       // Use same ID and type as key input report
-      hid_rpt_map[3].id = hidReportRefKeyIn[0];
-      hid_rpt_map[3].type = hidReportRefKeyIn[1];
-      hid_rpt_map[3].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_KB_IN_REPORT_VAL];
-      hid_rpt_map[3].cccdHandle = 0;
-      hid_rpt_map[3].mode = HID_PROTOCOL_MODE_BOOT;
-
-      // Boot mouse input report
-      // Use same ID and type as mouse input report
-      hid_rpt_map[4].id = hidReportRefMouseIn[0];
-      hid_rpt_map[4].type = hidReportRefMouseIn[1];
-      hid_rpt_map[4].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_MOUSE_IN_REPORT_VAL];
+      hid_rpt_map[4].id = hidReportRefKeyIn[0];
+      hid_rpt_map[4].type = hidReportRefKeyIn[1];
+      hid_rpt_map[4].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_KB_IN_REPORT_VAL];
       hid_rpt_map[4].cccdHandle = 0;
       hid_rpt_map[4].mode = HID_PROTOCOL_MODE_BOOT;
 
-      // Feature report
-      hid_rpt_map[5].id = hidReportRefFeature[0];
-      hid_rpt_map[5].type = hidReportRefFeature[1];
-      hid_rpt_map[5].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_VAL];
+      // Boot mouse input report
+      // Use same ID and type as mouse input report
+      hid_rpt_map[5].id = hidReportRefMouseIn[0];
+      hid_rpt_map[5].type = hidReportRefMouseIn[1];
+      hid_rpt_map[5].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_MOUSE_IN_REPORT_VAL];
       hid_rpt_map[5].cccdHandle = 0;
-      hid_rpt_map[5].mode = HID_PROTOCOL_MODE_REPORT;
+      hid_rpt_map[5].mode = HID_PROTOCOL_MODE_BOOT;
+
+      // Feature report
+      hid_rpt_map[6].id = hidReportRefFeature[0];
+      hid_rpt_map[6].type = hidReportRefFeature[1];
+      hid_rpt_map[6].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_VAL];
+      hid_rpt_map[6].cccdHandle = 0;
+      hid_rpt_map[6].mode = HID_PROTOCOL_MODE_REPORT;
 
 
   // Setup report ID map

--- a/main/ble_hid/hid_device_le_prf.c
+++ b/main/ble_hid/hid_device_le_prf.c
@@ -71,6 +71,8 @@ static const uint8_t hidReportMap[] = {
     0xC0,        //   End Collection
     0xC0,        // End Collection
 
+
+
     0x05, 0x01,  // Usage Pg (Generic Desktop)
     0x09, 0x06,  // Usage (Keyboard)
     0xA1, 0x01,  // Collection: (Application)
@@ -86,25 +88,7 @@ static const uint8_t hidReportMap[] = {
     0x75, 0x01,  //   Report Size (1)
     0x95, 0x08,  //   Report Count (8)
     0x81, 0x02,  //   Input: (Data, Variable, Absolute)
-    //
-    //   Reserved byte
-    0x95, 0x01,  //   Report Count (1)
-    0x75, 0x08,  //   Report Size (8)
-    0x81, 0x01,  //   Input: (Constant)
-    //
-    //   LED report
-    0x95, 0x05,  //   Report Count (5)
-    0x75, 0x01,  //   Report Size (1)
-    0x05, 0x08,  //   Usage Pg (LEDs)
-    0x19, 0x01,  //   Usage Min (1)
-    0x29, 0x05,  //   Usage Max (5)
-    0x91, 0x02,  //   Output: (Data, Variable, Absolute)
-    //
-    //   LED report padding
-    0x95, 0x01,  //   Report Count (1)
-    0x75, 0x03,  //   Report Size (3)
-    0x91, 0x01,  //   Output: (Constant)
-    //
+
     //   Key arrays (6 bytes)
     0x95, 0x06,  //   Report Count (6)
     0x75, 0x08,  //   Report Size (8)
@@ -116,7 +100,12 @@ static const uint8_t hidReportMap[] = {
     0x81, 0x00,  //   Input: (Data, Array)
     //
     0xC0,        // End Collection
+    
+    
+    
+    
     //
+
     0x05, 0x0C,   // Usage Pg (Consumer Devices)
     0x09, 0x01,   // Usage (Consumer Control)
     0xA1, 0x01,   // Collection (Application)
@@ -174,16 +163,6 @@ static const uint8_t hidReportMap[] = {
     0xC0,           //   End Collection
     0x81, 0x03,   //   Input (Const, Var, Abs)
     0xC0,            // End Collection
-    0x06, 0xFF, 0xFF, // Usage Page(Vendor defined)
-    0x09, 0xA5,       // Usage(Vendor Defined)
-    0xA1, 0x01,       // Collection(Application)
-    0x85, 0x04,   // Report Id (4)
-    0x09, 0xA6,   // Usage(Vendor defined)
-    0x09, 0xA9,   // Usage(Vendor defined)
-    0x75, 0x08,   // Report Size
-    0x95, 0x7F,   // Report Count = 127 Btyes
-    0x91, 0x02,   // Output(Data, Variable, Absolute)
-    0xC0,         // End Collection
 };
 
 /// Battery Service Attributes Indexes
@@ -240,13 +219,6 @@ static uint8_t hidReportRefMouseIn[HID_REPORT_REF_LEN] =
 static uint8_t hidReportRefKeyIn[HID_REPORT_REF_LEN] =
              { HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT };
 
-// HID Report Reference characteristic descriptor, LED output
-static uint8_t hidReportRefLedOut[HID_REPORT_REF_LEN] =
-             { HID_RPT_ID_LED_OUT, HID_REPORT_TYPE_OUTPUT };
-
-static uint8_t hidReportRefVendorOut[HID_REPORT_REF_LEN] =
-             {HID_RPT_ID_VENDOR_OUT, HID_REPORT_TYPE_OUTPUT};
-
 // HID Report Reference characteristic descriptor, Feature
 static uint8_t hidReportRefFeature[HID_REPORT_REF_LEN] =
              { HID_RPT_ID_FEATURE, HID_REPORT_TYPE_FEATURE };
@@ -288,7 +260,7 @@ static const uint8_t char_prop_read = ESP_GATT_CHAR_PROP_BIT_READ;
 static const uint8_t char_prop_write_nr = ESP_GATT_CHAR_PROP_BIT_WRITE_NR;
 static const uint8_t char_prop_read_write = ESP_GATT_CHAR_PROP_BIT_WRITE|ESP_GATT_CHAR_PROP_BIT_READ;
 static const uint8_t char_prop_read_notify = ESP_GATT_CHAR_PROP_BIT_READ|ESP_GATT_CHAR_PROP_BIT_NOTIFY;
-static const uint8_t char_prop_read_write_notify = ESP_GATT_CHAR_PROP_BIT_READ|ESP_GATT_CHAR_PROP_BIT_WRITE|ESP_GATT_CHAR_PROP_BIT_NOTIFY;
+//static const uint8_t char_prop_read_write_notify = ESP_GATT_CHAR_PROP_BIT_READ|ESP_GATT_CHAR_PROP_BIT_WRITE|ESP_GATT_CHAR_PROP_BIT_NOTIFY; //unused
 
 /// battary Service
 static const uint16_t battary_svc = ESP_GATT_UUID_BATTERY_SERVICE_SVC;
@@ -426,36 +398,7 @@ static esp_gatts_attr_db_t hidd_le_gatt_db[HIDD_LE_IDX_NB] =
                                                                        ESP_GATT_PERM_READ,
                                                                        sizeof(hidReportRefKeyIn), sizeof(hidReportRefKeyIn),
                                                                        hidReportRefKeyIn}},
-
-     // Report Characteristic Declaration
-    [HIDD_LE_IDX_REPORT_LED_OUT_CHAR]         = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid,
-                                                                         ESP_GATT_PERM_READ,
-                                                                         CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE,
-                                                                         (uint8_t *)&char_prop_read_write}},
-
-    [HIDD_LE_IDX_REPORT_LED_OUT_VAL]            = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_uuid,
-                                                                       ESP_GATT_PERM_READ|ESP_GATT_PERM_WRITE,
-                                                                       HIDD_LE_REPORT_MAX_LEN, 0,
-                                                                       NULL}},
-    [HIDD_LE_IDX_REPORT_LED_OUT_REP_REF]      =  {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_ref_descr_uuid,
-                                                                       ESP_GATT_PERM_READ,
-                                                                       sizeof(hidReportRefLedOut), sizeof(hidReportRefLedOut),
-                                                                       hidReportRefLedOut}},
     // Report Characteristic Declaration
-    [HIDD_LE_IDX_REPORT_VENDOR_OUT_CHAR]        = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid,
-                                                                         ESP_GATT_PERM_READ,
-                                                                         CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE,
-                                                                         (uint8_t *)&char_prop_read_write_notify}},
-    [HIDD_LE_IDX_REPORT_VENDOR_OUT_VAL]         = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_uuid,
-                                                                       ESP_GATT_PERM_READ|ESP_GATT_PERM_WRITE,
-                                                                       HIDD_LE_REPORT_MAX_LEN, 0,
-                                                                       NULL}},
-    [HIDD_LE_IDX_REPORT_VENDOR_OUT_REP_REF]     = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&hid_report_ref_descr_uuid,
-                                                                       ESP_GATT_PERM_READ,
-                                                                       sizeof(hidReportRefVendorOut), sizeof(hidReportRefVendorOut),
-                                                                       hidReportRefVendorOut}},
-
-        // Report Characteristic Declaration
     [HIDD_LE_IDX_REPORT_CC_IN_CHAR]         = {{ESP_GATT_AUTO_RSP}, {ESP_UUID_LEN_16, (uint8_t *)&character_declaration_uuid,
                                                                          ESP_GATT_PERM_READ,
                                                                          CHAR_DECLARATION_SIZE, CHAR_DECLARATION_SIZE,
@@ -543,6 +486,7 @@ void esp_hidd_prf_cb_hdl(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
 {
     switch(event) {
         case ESP_GATTS_REG_EVT: {
+            esp_ble_gap_config_local_icon (ESP_BLE_APPEARANCE_GENERIC_HID);
             esp_hidd_cb_param_t hidd_param;
             hidd_param.init_finish.state = param->reg.status;
             if(param->reg.app_id == HIDD_APP_ID) {
@@ -589,7 +533,8 @@ void esp_hidd_prf_cb_hdl(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
         case ESP_GATTS_CLOSE_EVT:
             break;
         case ESP_GATTS_WRITE_EVT: {
-            esp_hidd_cb_param_t cb_param = {0};
+			//was used for the vendor report, just left as example here.
+            /**esp_hidd_cb_param_t cb_param = {0};
             if (param->write.handle == hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_VENDOR_OUT_VAL] &&
                 hidd_le_env.hidd_cb != NULL) {
                 cb_param.vendor_write.conn_id = param->write.conn_id;
@@ -597,7 +542,7 @@ void esp_hidd_prf_cb_hdl(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                 cb_param.vendor_write.length = param->write.len;
                 cb_param.vendor_write.data = param->write.value;
                 (hidd_le_env.hidd_cb)(ESP_HIDD_EVENT_BLE_VENDOR_REPORT_WRITE_EVT, &cb_param);
-            }
+            }*/
             break;
         }
         case ESP_GATTS_CREAT_ATTR_TAB_EVT: {
@@ -765,43 +710,28 @@ static void hid_add_id_tbl(void)
       hid_rpt_map[2].cccdHandle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_CC_IN_CCC];
       hid_rpt_map[2].mode = HID_PROTOCOL_MODE_REPORT;
 
-      // LED output report
-      hid_rpt_map[3].id = hidReportRefLedOut[0];
-      hid_rpt_map[3].type = hidReportRefLedOut[1];
-      hid_rpt_map[3].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_LED_OUT_VAL];
-      hid_rpt_map[3].cccdHandle = 0;
-      hid_rpt_map[3].mode = HID_PROTOCOL_MODE_REPORT;
-
       // Boot keyboard input report
       // Use same ID and type as key input report
-      hid_rpt_map[4].id = hidReportRefKeyIn[0];
-      hid_rpt_map[4].type = hidReportRefKeyIn[1];
-      hid_rpt_map[4].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_KB_IN_REPORT_VAL];
-      hid_rpt_map[4].cccdHandle = 0;
-      hid_rpt_map[4].mode = HID_PROTOCOL_MODE_BOOT;
-
-      // Boot keyboard output report
-      // Use same ID and type as LED output report
-      hid_rpt_map[5].id = hidReportRefLedOut[0];
-      hid_rpt_map[5].type = hidReportRefLedOut[1];
-      hid_rpt_map[5].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_KB_OUT_REPORT_VAL];
-      hid_rpt_map[5].cccdHandle = 0;
-      hid_rpt_map[5].mode = HID_PROTOCOL_MODE_BOOT;
+      hid_rpt_map[3].id = hidReportRefKeyIn[0];
+      hid_rpt_map[3].type = hidReportRefKeyIn[1];
+      hid_rpt_map[3].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_KB_IN_REPORT_VAL];
+      hid_rpt_map[3].cccdHandle = 0;
+      hid_rpt_map[3].mode = HID_PROTOCOL_MODE_BOOT;
 
       // Boot mouse input report
       // Use same ID and type as mouse input report
-      hid_rpt_map[6].id = hidReportRefMouseIn[0];
-      hid_rpt_map[6].type = hidReportRefMouseIn[1];
-      hid_rpt_map[6].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_MOUSE_IN_REPORT_VAL];
-      hid_rpt_map[6].cccdHandle = 0;
-      hid_rpt_map[6].mode = HID_PROTOCOL_MODE_BOOT;
+      hid_rpt_map[4].id = hidReportRefMouseIn[0];
+      hid_rpt_map[4].type = hidReportRefMouseIn[1];
+      hid_rpt_map[4].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_BOOT_MOUSE_IN_REPORT_VAL];
+      hid_rpt_map[4].cccdHandle = 0;
+      hid_rpt_map[4].mode = HID_PROTOCOL_MODE_BOOT;
 
       // Feature report
-      hid_rpt_map[7].id = hidReportRefFeature[0];
-      hid_rpt_map[7].type = hidReportRefFeature[1];
-      hid_rpt_map[7].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_VAL];
-      hid_rpt_map[7].cccdHandle = 0;
-      hid_rpt_map[7].mode = HID_PROTOCOL_MODE_REPORT;
+      hid_rpt_map[5].id = hidReportRefFeature[0];
+      hid_rpt_map[5].type = hidReportRefFeature[1];
+      hid_rpt_map[5].handle = hidd_le_env.hidd_inst.att_tbl[HIDD_LE_IDX_REPORT_VAL];
+      hid_rpt_map[5].cccdHandle = 0;
+      hid_rpt_map[5].mode = HID_PROTOCOL_MODE_REPORT;
 
 
   // Setup report ID map

--- a/main/ble_hid/hidd_le_prf_int.h
+++ b/main/ble_hid/hidd_le_prf_int.h
@@ -127,8 +127,8 @@ typedef void (*esp_hidd_event_cb_t) (esp_hidd_cb_event_t event, esp_hidd_cb_para
 #define HID_RPT_ID_MOUSE_IN      1   // Mouse input report ID
 #define HID_RPT_ID_KEY_IN        2   // Keyboard input report ID
 #define HID_RPT_ID_CC_IN         3   //Consumer Control input report ID
-#define HID_RPT_ID_VENDOR_OUT    4   // Vendor output report ID
-#define HID_RPT_ID_JOY_IN        5   // Vendor output report ID
+#define HID_RPT_ID_VENDOR_OUT    0   // Vendor output report ID
+#define HID_RPT_ID_JOY_IN        0   // Vendor output report ID
 #define HID_RPT_ID_LED_OUT       0  // LED output report ID
 #define HID_RPT_ID_FEATURE       0  // Feature report ID
 
@@ -219,15 +219,7 @@ enum {
     HIDD_LE_IDX_REPORT_KEY_IN_VAL,
     HIDD_LE_IDX_REPORT_KEY_IN_CCC,
     HIDD_LE_IDX_REPORT_KEY_IN_REP_REF,
-    ///Report Led output
-    HIDD_LE_IDX_REPORT_LED_OUT_CHAR,
-    HIDD_LE_IDX_REPORT_LED_OUT_VAL,
-    HIDD_LE_IDX_REPORT_LED_OUT_REP_REF,
-
     /// Report Vendor
-    HIDD_LE_IDX_REPORT_VENDOR_OUT_CHAR,
-    HIDD_LE_IDX_REPORT_VENDOR_OUT_VAL,
-    HIDD_LE_IDX_REPORT_VENDOR_OUT_REP_REF,
 
     HIDD_LE_IDX_REPORT_CC_IN_CHAR,
     HIDD_LE_IDX_REPORT_CC_IN_VAL,

--- a/main/ble_hid/hidd_le_prf_int.h
+++ b/main/ble_hid/hidd_le_prf_int.h
@@ -124,13 +124,11 @@ typedef void (*esp_hidd_event_cb_t) (esp_hidd_cb_event_t event, esp_hidd_cb_para
 #define HID_NUM_REPORTS          9
 
 // HID Report IDs for the service
+#define HID_RPT_ID_FEATURE       0  // Feature report ID
 #define HID_RPT_ID_MOUSE_IN      1   // Mouse input report ID
 #define HID_RPT_ID_KEY_IN        2   // Keyboard input report ID
 #define HID_RPT_ID_CC_IN         3   //Consumer Control input report ID
-#define HID_RPT_ID_VENDOR_OUT    0   // Vendor output report ID
-#define HID_RPT_ID_JOY_IN        0   // Vendor output report ID
-#define HID_RPT_ID_LED_OUT       0  // LED output report ID
-#define HID_RPT_ID_FEATURE       0  // Feature report ID
+#define HID_RPT_ID_JOY_IN        4   // Joystick input report ID
 
 #define HIDD_APP_ID			0x1812//ATT_SVC_HID
 
@@ -219,8 +217,13 @@ enum {
     HIDD_LE_IDX_REPORT_KEY_IN_VAL,
     HIDD_LE_IDX_REPORT_KEY_IN_CCC,
     HIDD_LE_IDX_REPORT_KEY_IN_REP_REF,
-    /// Report Vendor
-
+    //Report Joystick input
+    HIDD_LE_IDX_REPORT_JOY_IN_CHAR,
+    HIDD_LE_IDX_REPORT_JOY_IN_VAL,
+    HIDD_LE_IDX_REPORT_JOY_IN_CCC,
+    HIDD_LE_IDX_REPORT_JOY_IN_REP_REF,
+    
+	//report consumer control
     HIDD_LE_IDX_REPORT_CC_IN_CHAR,
     HIDD_LE_IDX_REPORT_CC_IN_VAL,
     HIDD_LE_IDX_REPORT_CC_IN_CCC,

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -34,6 +34,7 @@
 
 #include "config.h"
 #include "ble_hid/hal_ble.h"
+#include "ble_hid/hid_dev.h"
 
 #include "esp_gap_ble_api.h"
 //#include "esp_hidd_prf_api.h"
@@ -468,12 +469,17 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
 				cmdBuffer->expectedBytes--;
 				if (!cmdBuffer->expectedBytes) {
 					if (cmdBuffer->buf[1] == 0x00) {   // keyboard report				
-						// TBD: synchonize with semaphore!	
-						ESP_LOGE(EXT_UART_TAG,"TBD: implement RAW keyboard");
-						/*if(HID_kbdmousejoystick_rawKeyboard(cmdBuffer->buf,8) != ESP_OK)
-						{
-							ESP_LOGE(EXT_UART_TAG,"Error sending raw kbd");
-						} else ESP_LOGI(EXT_UART_TAG,"Keyboard sent");*/
+						uint8_t kbd[HID_KEYBOARD_IN_RPT_LEN];
+						kbd[0] = cmdBuffer->buf[0];
+						kbd[1] = cmdBuffer->buf[2];
+						kbd[2] = cmdBuffer->buf[3];
+						kbd[3] = cmdBuffer->buf[4];
+						kbd[4] = cmdBuffer->buf[5];
+						kbd[5] = cmdBuffer->buf[6];
+						kbd[6] = cmdBuffer->buf[7];
+						kbd[7] = 0;
+						hid_dev_send_report(hidd_le_env.gatt_if, getConnID(),
+							HID_RPT_ID_KEY_IN, HID_REPORT_TYPE_INPUT, HID_KEYBOARD_IN_RPT_LEN, kbd);
 					} else if (cmdBuffer->buf[1] == 0x03) {  // mouse report
 						hid.cmd[0] = 0x02;
 						hid.cmd[1] = cmdBuffer->buf[2]; //buttons


### PR DESCRIPTION
Main ideas of removing the vendor report is from the updated espressif example.

Windows is much more picky regarding unused GATT attributes.
In our case, there was a HID vendor report included, which
was triggering the problem. The keyboard LED report was removed too.

Works as expected (Mouse / Keyboard via BT):
-) Android (LineageOS 16.0 -> Android 9)
-) Debian Testing
-) iOS 13.3.1
-) Win10 Enterprise (Virtual Box)

@ChrisVeigl Please test this if possible (sparkfun ESP32thing stand-alone is sufficient).