### PR TITLE
Implemented rate limiter for HID reports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ _Note:_ We do not test these on a regular basis!
 |$GP|Get BLE pairings|--|Prints out all paired devices' MAC adress. The order is used for DP as well, starting with 0|
 |$DP|Delete one pairing|number of pairing, given as ASCII-characer '0'-'9'|Deletes one pairing. The pairing number is determined by the command GP|
 |$PM|Set pairing mode|'0' / '1'|Enables (1) or disables (0) discovery/advertising and terminates an exisiting connection if enabled|
+|$RL|Set BLE rate limiter|0-100000|Set the minimum time between two BLE GATT indicates (HID reports), if enabled in menuconfig|
 |$NAME|Set BLE device name|name as ASCII string|Set the device name to the given name. Restart required.|
 
 ### HID input

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ _Note:_ We do not test these on a regular basis!
 |$GP|Get BLE pairings|--|Prints out all paired devices' MAC adress. The order is used for DP as well, starting with 0|
 |$DP|Delete one pairing|number of pairing, given as ASCII-characer '0'-'9'|Deletes one pairing. The pairing number is determined by the command GP|
 |$PM|Set pairing mode|'0' / '1'|Enables (1) or disables (0) discovery/advertising and terminates an exisiting connection if enabled|
-|$RL|Set BLE rate limiter|0-100000|Set the minimum time between two BLE GATT indicates (HID reports), if enabled in menuconfig|
+|$RL|Set BLE rate limiter|0-100000|Set the minimum time between two BLE GATT indicates (HID reports), if enabled in menuconfig. __Note:__ Values above 5000 are not practical, mouse reports are sent very slowly!|
 |$NAME|Set BLE device name|name as ASCII string|Set the device name to the given name. Restart required.|
 
 ### HID input

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -70,12 +70,12 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 			Note: Only mouse & joystick reports are handled by the rate limiter!
 			
 	config MODULE_RATELIMITERACCUMULATE
-		bool "Accumulate mouse HID packets if rate limiter hits (NOT RECOMMENDED)"
+		bool "Accumulate mouse HID packets if rate limiter hits"
 		depends on MODULE_USERATELIMITER
-		default n
+		default y
 		help
 			If enabled, relative mouse movements are accumulated and
-			sent on next occasion. If disabled, the HID report is discarded.
+			sent on next occasion (timer triggered). If disabled, the HID report is discarded.
 
 	config MODULE_RATELIMITERDEFAULT
 		int "Ratelimiter time between HID commands [us]"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -56,7 +56,32 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 			If enabled, the module denies pairing requests by default.
 			It is possible to enable the pairing by sending the pairing en-/disable command
 			via the serial interface.
-		
+
+	config MODULE_USERATELIMITER
+		bool "Enable BLE transmission rate limiter"
+		default y
+		help
+			Enables a rate limiter, to avoid any delayed HID commands
+			on the BLE central device. If enabled, it is possible to
+			define the minimal time between a HID command via the
+			UART command "$RL<us>" (e.g. "$RL10000" for 10ms).
+			The configuration setting "Rate limiter default" sets the
+			default value on boot.
+			Note: Only mouse & joystick reports are handled by the rate limiter!
+			
+	config MODULE_RATELIMITERACCUMULATE
+		bool "Accumulate mouse HID packets if rate limiter hits"
+		depends on MODULE_USERATELIMITER
+		default n
+		help
+			If enabled, relative mouse movements are accumulated and
+			sent on next occasion. If disabled, the HID report is discarded.
+
+	config MODULE_RATELIMITERDEFAULT
+		int "Ratelimiter time between HID commands [us]"
+		depends on MODULE_USERATELIMITER
+		default 0
+        range 0 100000
 
 	config USE_AS_FLIPMOUSE_FABI
 		bool "Use project as FLipMouse/FABI Bluetooth module"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -80,8 +80,8 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 	config MODULE_RATELIMITERDEFAULT
 		int "Ratelimiter time between HID commands [us]"
 		depends on MODULE_USERATELIMITER
-		default 100
-        range 0 100000
+		default 500
+        range 100 100000
 
 	config USE_AS_FLIPMOUSE_FABI
 		bool "Use project as FLipMouse/FABI Bluetooth module"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -70,7 +70,7 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 			Note: Only mouse & joystick reports are handled by the rate limiter!
 			
 	config MODULE_RATELIMITERACCUMULATE
-		bool "Accumulate mouse HID packets if rate limiter hits"
+		bool "Accumulate mouse HID packets if rate limiter hits (NOT RECOMMENDED)"
 		depends on MODULE_USERATELIMITER
 		default n
 		help
@@ -80,7 +80,7 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 	config MODULE_RATELIMITERDEFAULT
 		int "Ratelimiter time between HID commands [us]"
 		depends on MODULE_USERATELIMITER
-		default 0
+		default 100
         range 0 100000
 
 	config USE_AS_FLIPMOUSE_FABI

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -263,6 +263,9 @@ static void hidd_event_callback(esp_hidd_cb_event_t event, esp_hidd_cb_param_t *
         ESP_LOGI(HID_DEMO_TAG, "%s, ESP_HIDD_EVENT_BLE_VENDOR_REPORT_WRITE_EVT", __func__);
         ESP_LOG_BUFFER_HEX(HID_DEMO_TAG, param->vendor_write.data, param->vendor_write.length);
     }
+    case ESP_HIDD_EVENT_BLE_LED_OUT_WRITE_EVT: {
+        ESP_LOGI(HID_DEMO_TAG, "%s, ESP_HIDD_EVENT_BLE_LED_OUT_WRITE_EVT, keyboard LED value: %d", __func__, param->vendor_write.data[0]);
+    }
     default:
         break;
     }

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -630,6 +630,21 @@ void uart_console_task(void *pvParameters)
             ESP_LOGI(CONSOLE_UART_TAG,"Not connected, ignoring '%c'", character);
         } else {
             switch (character) {
+			case 'm':
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_MUTE,true);
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_MUTE,false);
+				ESP_LOGI(CONSOLE_UART_TAG,"consumer: mute");
+				break;
+			case 'p':
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_VOLUME_UP,true);
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_VOLUME_UP,false);
+				ESP_LOGI(CONSOLE_UART_TAG,"consumer: volume plus");
+				break;
+			case 'o':
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_VOLUME_DOWN,true);
+				esp_hidd_send_consumer_value(hid_conn_id,HID_CONSUMER_VOLUME_DOWN,false);
+				ESP_LOGI(CONSOLE_UART_TAG,"consumer: volume minus");
+				break;
             case 'a':
                 esp_hidd_send_mouse_value(hid_conn_id,0,-MOUSE_SPEED,0,0);
                 ESP_LOGI(CONSOLE_UART_TAG,"mouse: a");

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -476,14 +476,12 @@ void processCommand(struct cmdBuf *cmdBuffer)
             ESP_LOGE(EXT_UART_TAG,"RL: cannot parse, need integer <0-100000>");
             return;
         }
-        if(newinterval < 0 || newinterval > 100000) {
-            ESP_LOGE(EXT_UART_TAG,"RL: invalid parameter, need integer <0-100000>");
+        if(newinterval < 100 || newinterval > 100000) {
+            ESP_LOGE(EXT_UART_TAG,"RL: invalid parameter, need integer <100-100000>");
             return;
         }
-        ///TODO: call setter/getter for rate limiter
-        ESP_LOGE(EXT_UART_TAG,"RL: TBD!");
-        //ESP_LOGI(EXT_UART_TAG,"RL: rate limit interval set from %lld to %d", timeIntervalHIDCommand, newinterval);
-        //timeIntervalHIDCommand = newinterval;
+        ESP_LOGI(EXT_UART_TAG,"RL: rate limit interval set from %d to %d", esp_hidd_get_interval(), newinterval);
+        esp_hidd_set_interval(newinterval);
         return;
 	}
     #endif

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -600,7 +600,7 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
 									if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
 								}
 							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
-								ESP_LOGI(EXT_UART_TAG,"Rate limit: discard mouse report");
+								ESP_LOGV(EXT_UART_TAG,"Rate limit: discard mouse report");
 							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
 						}
 					#else  /* CONFIG_MODULE_USERATELIMITER */

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -121,6 +121,7 @@ struct cmdBuf {
     #if CONFIG_MODULE_USERATELIMITER
 		int64_t lastTimeHIDCommandSent;
 		int16_t accumValues[3];
+		uint8_t buttonstate;
     #endif
     uint8_t buf[MAX_CMDLEN];
 };
@@ -490,6 +491,7 @@ void processCommand(struct cmdBuf *cmdBuffer)
         }
         ESP_LOGI(EXT_UART_TAG,"RL: rate limit interval set from %lld to %d", timeIntervalHIDCommand, newinterval);
         timeIntervalHIDCommand = newinterval;
+        return;
 	}
     #endif
 
@@ -585,26 +587,38 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
 										current[i] = cmdBuffer->accumValues[i];
 										cmdBuffer->accumValues[i] = 0;
 									}
-									esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],current[0],current[1],current[2]);
 								}
+								esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],current[0],current[1],current[2]);
 							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
 								esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
 							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
 							cmdBuffer->lastTimeHIDCommandSent = esp_timer_get_time();
+							cmdBuffer->buttonstate = cmdBuffer->buf[2];
 						} else {
-							#if CONFIG_MODULE_RATELIMITERACCUMULATE
-								for(uint8_t i = 0; i<3; i++)
-								{
-									//add current values
-									cmdBuffer->accumValues[i] += cmdBuffer->buf[i+3];
-									//limit accumulated value, if we hit the upper limit, there 
-									// is something going wrong...
-									if(cmdBuffer->accumValues[i] > 6000) cmdBuffer->accumValues[i] = 6000;
-									if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
-								}
-							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
-								ESP_LOGV(EXT_UART_TAG,"Rate limit: discard mouse report");
-							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+							//if the button state of the mouse changes, we
+							//will send the report, even if the interval has not passed yet.
+							//this case is not happening often, but it should be considered to avoid
+							//sticky mouse buttons.
+							//Note that the transmission will not modify the accumulate buffer.
+							if(cmdBuffer->buf[2] != cmdBuffer->buttonstate)
+							{
+								ESP_LOGI(EXT_UART_TAG,"Button changed, sending out of interval");
+								esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
+							} else {
+								#if CONFIG_MODULE_RATELIMITERACCUMULATE
+									for(uint8_t i = 0; i<3; i++)
+									{
+										//add current values
+										cmdBuffer->accumValues[i] += cmdBuffer->buf[i+3];
+										//limit accumulated value, if we hit the upper limit, there 
+										// is something going wrong...
+										if(cmdBuffer->accumValues[i] > 6000) cmdBuffer->accumValues[i] = 6000;
+										if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
+									}
+								#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+									ESP_LOGV(EXT_UART_TAG,"Rate limit: discard mouse report");
+								#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+							}
 						}
 					#else  /* CONFIG_MODULE_USERATELIMITER */
 						esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -603,7 +603,7 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
 									if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
 								}
 							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
-								ESP_LOGI(EXT_UART_TAG,"Rate limit: discard mouse report");
+								ESP_LOGV(EXT_UART_TAG,"Rate limit: discard mouse report");
 							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
 						}
 					#else  /* CONFIG_MODULE_USERATELIMITER */

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -61,7 +61,7 @@
 /**
  * Brief:
  * This example Implemented BLE HID device profile related functions, in which the HID device
- * has 4 Reports (1 is mouse, 2 is keyboard and LED, 3 is Consumer Devices, 4 is Vendor devices).
+ * has 4 Reports (1 is mouse, 2 is keyboard and LED, 3 is Consumer Devices, 4 is Joystick).
  * Users can choose different reports according to their own application scenarios.
  * BLE HID profile inheritance and USB HID class.
  */
@@ -98,7 +98,6 @@
 
 static uint16_t hid_conn_id = 0;
 static bool sec_conn = false;
-static bool send_volum_up = false;
 #define CHAR_DECLARATION_SIZE   (sizeof(uint8_t))
 
 static void hidd_event_callback(esp_hidd_cb_event_t event, esp_hidd_cb_param_t *param);
@@ -119,8 +118,16 @@ struct cmdBuf {
     int state;
     int expectedBytes;
     int bufferLength;
+    #if CONFIG_MODULE_USERATELIMITER
+		int64_t lastTimeHIDCommandSent;
+		int16_t accumValues[3];
+    #endif
     uint8_t buf[MAX_CMDLEN];
 };
+
+#if CONFIG_MODULE_USERATELIMITER
+	int64_t timeIntervalHIDCommand = CONFIG_MODULE_RATELIMITERDEFAULT;
+#endif
 
 static uint8_t manufacturer[19]= {'A', 's', 'T', 'e', 'R', 'I', 'C', 'S', ' ', 'F', 'o', 'u', 'n', 'd', 'a', 't', 'i', 'o', 'n'};
 
@@ -327,6 +334,7 @@ void processCommand(struct cmdBuf *cmdBuffer)
     // $GP
     // $DPx (number of paired device, starting with 0)
     // $NAME set name of bluetooth device
+    // $RL<0-100000>
 
     if(cmdBuffer->bufferLength < 2) return;
     //easier this way than typecast in each str* function
@@ -466,6 +474,24 @@ void processCommand(struct cmdBuf *cmdBuffer)
         else ESP_LOGI(EXT_UART_TAG,"NAME: given bt name is too long or too short");
         return;
     }
+    
+    //set rate limiter interval
+    #if CONFIG_MODULE_USERATELIMITER
+    if(strncmp(input,"RL",2) == 0)
+    {
+		int newinterval;
+        if (!(get_int(input,2,&newinterval))) {
+            ESP_LOGE(EXT_UART_TAG,"RL: cannot parse, need integer <0-100000>");
+            return;
+        }
+        if(newinterval < 0 || newinterval > 100000) {
+            ESP_LOGE(EXT_UART_TAG,"RL: invalid parameter, need integer <0-100000>");
+            return;
+        }
+        ESP_LOGI(EXT_UART_TAG,"RL: rate limit interval set from %lld to %d", timeIntervalHIDCommand, newinterval);
+        timeIntervalHIDCommand = newinterval;
+	}
+    #endif
 
     ESP_LOGE(EXT_UART_TAG,"No command executed with: %s ; len= %d\n",input,len);
 }
@@ -488,9 +514,9 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
 
     case CMDSTATE_GET_RAW:
         cmdBuffer->buf[cmdBuffer->bufferLength]=character;
-        if ((cmdBuffer->bufferLength == 1) && (character==0x01)) { // we have a joystick report: increase by 4 bytes
+        if ((cmdBuffer->bufferLength == 1) && (character==0x01)) { // we have a joystick report: increase by 6 bytes
             cmdBuffer->expectedBytes += 6;
-            //ESP_LOGI(EXT_UART_TAG,"expecting 4 more bytes for joystick");
+            //ESP_LOGI(EXT_UART_TAG,"expecting 6 more bytes for joystick");
         }
 
         cmdBuffer->bufferLength++;
@@ -499,15 +525,90 @@ void uart_parse_command (uint8_t character, struct cmdBuf * cmdBuffer)
             if(sec_conn == false) {
                 ESP_LOGI(EXT_UART_TAG,"not connected, cannot send report");
             } else {
+				/////// Keyboard
                 if (cmdBuffer->buf[1] == 0x00) {   // keyboard report
                     esp_hidd_send_keyboard_value(hid_conn_id,cmdBuffer->buf[0],&cmdBuffer->buf[2],6);
+                    
+                /////// Joystick
                 } else if (cmdBuffer->buf[1] == 0x01) {  // joystick report
-                    ESP_LOGI(EXT_UART_TAG,"joystick: buttons: 0x%X:0x%X:0x%X:0x%X",cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
-                    //uint8_t joy[HID_JOYSTICK_IN_RPT_LEN];
-                    //memcpy(joy,&cmdBuffer->buf[2],HID_JOYSTICK_IN_RPT_LEN);
-                    ///@todo esp_hidd_send_joystick_value...
+					#if CONFIG_MODULE_USEJOYSTICK
+						///If we are using the rate limiter, check for the last transmission of a HID command.
+						///Note: as we sent absolute data for joystick axis, I think it is no problem to
+						/// discard any packets. If we get them too fast, many of them are still sent with the current values.
+						#if CONFIG_MODULE_USERATELIMITER
+							//check interval, jst to be sure use the absolute value of the subtraction.
+							if(abs(esp_timer_get_time() - cmdBuffer->lastTimeHIDCommandSent) > timeIntervalHIDCommand)
+							{
+								//esp_hidd_send_joystick_value(hid_conn_id,&cmdBuffer->buf[2],12);
+								
+								cmdBuffer->lastTimeHIDCommandSent = esp_timer_get_time();
+							} else {
+								ESP_LOGI(EXT_UART_TAG,"Rate limit: discard joystick report");
+							}
+						#else /* CONFIG_MODULE_USERATELIMITER */
+							//esp_hidd_send_joystick_value(hid_conn_id,&cmdBuffer->buf[2],12);
+						#endif /* CONFIG_MODULE_USERATELIMITER */
+					#else
+						ESP_LOGE(EXT_UART_TAG,"Got joystick report, although joystick is not built-in!");
+					#endif /* CONFIG_MODULE_USEJOYSTICK */
+                    //ESP_LOGI(EXT_UART_TAG,"joystick: buttons: 0x%X:0x%X:0x%X:0x%X",cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
+                    
+                /////// Mouse
                 } else if (cmdBuffer->buf[1] == 0x03) {  // mouse report
-                    esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
+					///If we are using the rate limiter, check for the last transmission of a HID command.
+					/// Note: For mouse reports, updated values are either accumulated or discarded.
+					///  Especially with the FLipMouse, many small reports with small movements are sent.
+					///  So either we discard them (easy way) or accumulate the axis' values & sent the final value next possible occasion.
+					#if CONFIG_MODULE_USERATELIMITER
+						//check interval, just to be sure use the absolute value of the subtraction.
+						if(abs(esp_timer_get_time() - cmdBuffer->lastTimeHIDCommandSent) > timeIntervalHIDCommand)
+						{
+							#if CONFIG_MODULE_RATELIMITERACCUMULATE
+								//get for all 3 relative axis the current value, limit if necessary
+								//subtract from accumulated value the amount which is sent now.
+								int8_t current[3];
+								for(uint8_t i = 0; i<3; i++)
+								{
+									//add current values
+									cmdBuffer->accumValues[i] += cmdBuffer->buf[i+3];
+									//limit accumulated value, if we hit the upper limit, there 
+									// is something going wrong...
+									if(cmdBuffer->accumValues[i] > 6000) cmdBuffer->accumValues[i] = 6000;
+									if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
+									
+									//limit values on upper&lower boundaries
+									if(cmdBuffer->accumValues[i] > 127) {
+										current[i] = 127; cmdBuffer->accumValues[i] -= 127;
+									} else if(cmdBuffer->accumValues[i] < -127) {
+										current[i] = -127; cmdBuffer->accumValues[i] += 127;
+									} else {
+										current[i] = cmdBuffer->accumValues[i];
+										cmdBuffer->accumValues[i] = 0;
+									}
+									esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],current[0],current[1],current[2]);
+								}
+							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+								esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
+							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+							cmdBuffer->lastTimeHIDCommandSent = esp_timer_get_time();
+						} else {
+							#if CONFIG_MODULE_RATELIMITERACCUMULATE
+								for(uint8_t i = 0; i<3; i++)
+								{
+									//add current values
+									cmdBuffer->accumValues[i] += cmdBuffer->buf[i+3];
+									//limit accumulated value, if we hit the upper limit, there 
+									// is something going wrong...
+									if(cmdBuffer->accumValues[i] > 6000) cmdBuffer->accumValues[i] = 6000;
+									if(cmdBuffer->accumValues[i] < -6000) cmdBuffer->accumValues[i] = -6000;
+								}
+							#else /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+								ESP_LOGI(EXT_UART_TAG,"Rate limit: discard mouse report");
+							#endif /* CONFIG_MODULE_RATELIMITERACCUMULATE */
+						}
+					#else  /* CONFIG_MODULE_USERATELIMITER */
+						esp_hidd_send_mouse_value(hid_conn_id,cmdBuffer->buf[2],cmdBuffer->buf[3],cmdBuffer->buf[4],cmdBuffer->buf[5]);
+					#endif  /* CONFIG_MODULE_USERATELIMITER */
                 }
                 else ESP_LOGE(EXT_UART_TAG,"Unknown RAW HID packet");
             }
@@ -538,6 +639,10 @@ void uart_external_task(void *pvParameters)
 {
     char character;
     struct cmdBuf cmdBuffer;
+    #if CONFIG_MODULE_USERATELIMITER
+		cmdBuffer.lastTimeHIDCommandSent = esp_timer_get_time();
+		cmdBuffer.accumValues[0] = cmdBuffer.accumValues[1] = cmdBuffer.accumValues[2] = 0;
+    #endif
 
 
     //Install UART driver, and get the queue.
@@ -605,6 +710,10 @@ void uart_console_task(void *pvParameters)
     uint8_t hid_or_command = 0;
     struct cmdBuf commands;
     commands.state=CMDSTATE_IDLE;
+    #if CONFIG_MODULE_USERATELIMITER
+		commands.lastTimeHIDCommandSent = esp_timer_get_time();
+		commands.accumValues[0] = commands.accumValues[1] = commands.accumValues[2] = 0;
+    #endif
 
     //Install UART driver, and get the queue.
     uart_driver_install(CONSOLE_UART_NUM, UART_FIFO_LEN * 2, UART_FIFO_LEN * 2, 0, NULL, 0);

--- a/main/esp_hidd_prf_api.h
+++ b/main/esp_hidd_prf_api.h
@@ -162,6 +162,20 @@ void esp_hidd_send_keyboard_value(uint16_t conn_id, key_mask_t special_key_mask,
 
 void esp_hidd_send_mouse_value(uint16_t conn_id, uint8_t mouse_button, int8_t mickeys_x, int8_t mickeys_y, int8_t wheel);
 
+#if CONFIG_MODULE_USERATELIMITER
+/**
+ * @brief Set the new interval for the ratelimiter (in us)
+ * @param newinterval New interval [us]
+ */
+void esp_hidd_set_interval(uint32_t newinterval);
+
+/**
+ * @brief Get the current interval for the ratelimiter (in us)
+ * @return Current interval [us]
+ */
+uint32_t esp_hidd_get_interval(void);
+#endif /* CONFIG_MODULE_USERATELIMITER */
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/esp_hidd_prf_api.h
+++ b/main/esp_hidd_prf_api.h
@@ -31,6 +31,7 @@ typedef enum {
     ESP_HIDD_EVENT_BLE_CONNECT,                         
     ESP_HIDD_EVENT_BLE_DISCONNECT,
     ESP_HIDD_EVENT_BLE_VENDOR_REPORT_WRITE_EVT,
+    ESP_HIDD_EVENT_BLE_LED_OUT_WRITE_EVT,
 } esp_hidd_cb_event_t;
 
 /// HID config status

--- a/main/hidd_le_prf_int.h
+++ b/main/hidd_le_prf_int.h
@@ -48,7 +48,7 @@
 #define HID_RPT_ID_CC_IN         2   //Consumer Control input report ID
 #define HID_RPT_ID_MOUSE_IN      3   // Mouse input report ID
 #define HID_RPT_ID_VENDOR_OUT    4   // Vendor output report ID
-#define HID_RPT_ID_LED_OUT       0  // LED output report ID
+#define HID_RPT_ID_LED_OUT       1  // LED output report ID
 #define HID_RPT_ID_FEATURE       0  // Feature report ID
 
 #define HIDD_APP_ID			0x1812//ATT_SVC_HID


### PR DESCRIPTION
Added new config variables for KConfig:
-) enabling rate limiter
-) set interval in microseconds
-) Either accumulate mouse movements or discard reports when sent too fast