### PR TITLE
Introduction of command '$UG' for firmware update

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ _Note:_ We do not test these on a regular basis!
 |$DP|Delete one pairing|number of pairing, given as ASCII-characer '0'-'9'|Deletes one pairing. The pairing number is determined by the command GP|
 |$PM|Set pairing mode|'0' / '1'|Enables (1) or disables (0) discovery/advertising and terminates an exisiting connection if enabled|
 |$NAME|Set BLE device name|name as ASCII string|Set the device name to the given name. Restart required.|
+|$UG|Initiating firmware update|--|Boot partition is set to 'factory', if available. Device is restarted and expects firmware (.bin) via UART2|
 
 ### HID input
 

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -386,7 +386,6 @@ static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param
 				//ESP_LOGI(HID_DEMO_TAG, "\n");
 				if (adv_name != NULL) {
 					//store name to BT addr...
-					/*
 					esp_log_buffer_hex(HID_DEMO_TAG, scan_result->scan_rst.bda, 6);
 					esp_log_buffer_char(HID_DEMO_TAG, adv_name, adv_name_len);
 					adv_name[adv_name_len] = '\0';
@@ -397,7 +396,6 @@ static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param
 					{
 						ESP_LOGI(HID_DEMO_TAG,"Saved %s to %s",adv_name, key);
 					} else ESP_LOGW(HID_DEMO_TAG,"Error saving %s for %s",adv_name,key);
-					*/
 				}
 				break;
 			case ESP_GAP_SEARCH_INQ_CMPL_EVT:

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -15,7 +15,7 @@
  * MA 02110-1301, USA.
  *
  *
- * Copyright 2020, Benjamin Aigner <beni@asterics-foundation.org>,<aignerb@technikum-wien.at>
+ * Copyright 2020, Benjamin Aigner <beni@asterics-foundation.org>,<aignerb@technikum-wien.at>, Junaid Khan <junaid.khan.wien@gmail.com>
  *
  * This file is mostly based on the Espressif ESP32 BLE HID example.
  * Adaption were made for:
@@ -23,6 +23,7 @@
  * * console input for testing purposes
  * * Joystick support (replacing vendor report)
  * * command input via UART for controlling the BLE interface (get & delete pairings,...)
+ * * Firmware update possible via UART (factory partition required)
  *
  */
 


### PR DESCRIPTION
The UART command '$UG' triggers a firmware update:
The boot partition is set to 'factory'. If sucessful the device restarts and boots directly into factory partition (native_ota_example). The firmware (.bin file) can then be uploaded directly via 'EXT_UART'.

It is required that partition-table includes a partition of type 'factory'. If not found ESP returns to normal functionality.

Sucessful transfer of firmware and SHA-256 verification is handled by factory firmware.