### PR TITLE
Key value store

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ _Note:_ We do not test these on a regular basis!
 |$DP|Delete one pairing|number of pairing, given as ASCII-characer '0'-'9'|Deletes one pairing. The pairing number is determined by the command GP|
 |$PM|Set pairing mode|'0' / '1'|Enables (1) or disables (0) discovery/advertising and terminates an exisiting connection if enabled|
 |$NAME|Set BLE device name|name as ASCII string|Set the device name to the given name. Restart required.|
+|$SV|Set a key/value pair |key value| Set a value to ESP32 NVS storage, e.g. "$SV testkey This is a testvalue". Note: no spaces in the key! Returns "OK xx/yy used/free" on success, NVS:"error code" otherwise.|
+|$GV|Get a key/value pair |key| Get a value from ESP32 NVS storage, e.g. "$GV testkey". Note: no spaces in the key!|
+|$CV|Clear all key/value pairs |--| Delete all stored key/value pairs from $SV.|
 
 ### HID input
 

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -559,7 +559,7 @@ void processCommand(struct cmdBuf *cmdBuffer)
 			ESP_LOGI(EXT_UART_TAG,"set - %s:%s - used:%d,free:%d",key,nvspayload,nvs_stats.used_entries, nvs_stats.free_entries);
 			if(cmdBuffer->sendToUART != 0) 
 			{
-				uart_write_bytes(EX_UART_NUM, "NVS:OK ", strlen(esp_err_to_name(ret)));
+				uart_write_bytes(EX_UART_NUM, "NVS:OK ", strlen("NVS:OK "));
 				char stats[64];
 				sprintf(stats,"%d/%d - used/free",nvs_stats.used_entries, nvs_stats.free_entries);
 				uart_write_bytes(EX_UART_NUM,stats,strnlen(stats,64));

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -515,11 +515,16 @@ void processCommand(struct cmdBuf *cmdBuffer)
 				uart_write_bytes(EX_UART_NUM,nl,sizeof(nl)); //newline
 			}
 		} else {
-			//send back OK
-			ESP_LOGI(EXT_UART_TAG,"set - %s:%s",key,nvspayload);
+			//send back OK & used/free entries
+			nvs_stats_t nvs_stats;
+			nvs_get_stats(NULL, &nvs_stats);
+			ESP_LOGI(EXT_UART_TAG,"set - %s:%s - used:%d,free:%d",key,nvspayload,nvs_stats.used_entries, nvs_stats.free_entries);
 			if(cmdBuffer->sendToUART != 0) 
 			{
-				uart_write_bytes(EX_UART_NUM, "NVS:OK", strlen(esp_err_to_name(ret)));
+				uart_write_bytes(EX_UART_NUM, "NVS:OK ", strlen(esp_err_to_name(ret)));
+				char stats[64];
+				sprintf(stats,"%d/%d - used/free",nvs_stats.used_entries, nvs_stats.free_entries);
+				uart_write_bytes(EX_UART_NUM,stats,strnlen(stats,64));
 				uart_write_bytes(EX_UART_NUM,nl,sizeof(nl)); //newline
 			}
 		}

--- a/main/ble_hidd_demo_main.c
+++ b/main/ble_hidd_demo_main.c
@@ -439,6 +439,7 @@ void processCommand(struct cmdBuf *cmdBuffer)
     // $NAME set name of bluetooth device
     // $GV <key>  get the value of the given key from NVS. Note: no spaces in <key>! max. key length: 15
     // $SV <key> <value> set the value of the given key & store to NVS. Note: no spaces in <key>!
+    // $CV clear all key/value pairs set with $SV
 
     if(cmdBuffer->bufferLength < 2) return;
     //easier this way than typecast in each str* function
@@ -451,6 +452,22 @@ void processCommand(struct cmdBuf *cmdBuffer)
     esp_err_t ret;
 
 	/**++++ key/value storing ++++*/
+	if(strncmp(input,"CV ", 2) == 0)
+	{
+		//no error checks here, because all errors
+		//are related to the NVS part, which cannot be fixed via
+		//the UART console
+		nvs_erase_all(nvs_storage_h);
+		//commit NVS storage
+		ret = nvs_commit(nvs_storage_h);
+		ESP_LOGI(EXT_UART_TAG,"cleared all NVS key/value pairs");
+		if(cmdBuffer->sendToUART != 0) 
+		{
+			uart_write_bytes(EX_UART_NUM, "NVS:OK",strlen("NVS:OK"));
+			uart_write_bytes(EX_UART_NUM,nl,sizeof(nl)); //newline
+		}
+		return;
+	}
 	if(strncmp(input,"GV ", 3) == 0)
 	{
 		char* work = (char*)cmdBuffer->buf;


### PR DESCRIPTION
Added commands to store key/value pairs via the UART interface with these commands:
* ```$SV <key> <value>``` set a value for the given key, e.g. ```$SV keyname This is a test value```.
Output: "OK: xx/yy used/free", e.g. "OK: 93/664 used/free".
Notes: no spaces in key names allowed!
* ```$GV <key>``` get the value for the given key, e.g. ```$GV keyname```
Output: "<value", e.g. "This is a test value"
Notes: if the given key is not set, the output will be "NVS:ESP_ERR_NVS_NOT_FOUND"
* ```$CV``` clear all set key/value pairs