### PR TITLE
Enable full range of GPIOs for UARTs and LEDs

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -3,17 +3,17 @@ menu "esp32_mouse_keyboard - FLipMouse & FABI config"
 	config MODULE_RX_PIN
 		int "RX pin for command/HID UART"
 		default 17
-        range 1 25
+        range 1 39
         
 	config MODULE_TX_PIN
 		int "TX pin for command/HID UART"
 		default 16
-        range 1 25
+        range 1 39
         
 	config MODULE_LED_PIN
 		int "LED connection indicator pin"
 		default 5
-        range 1 25
+        range 1 39
     
     config MODULE_UART_NR
 		int "UART interface number"


### PR DESCRIPTION
On some ESP32 boards, the low number GPIOs might be used by embedded peripheral. This change enable the 39 GPIOs to be selected for UAR and LED