### PR TITLE
Fixing issue #55, cleanup

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -2,7 +2,7 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 
-#define MODULE_ID "ESP32miniBT_v0.3"
+#define MODULE_ID "ESP32miniBT_v0.3.2"
 
 #if CONFIG_MODULE_FLIPMOUSE
     #define GATTS_TAG "FLipMouse"

--- a/main/hid_device_le_prf.c
+++ b/main/hid_device_le_prf.c
@@ -588,7 +588,7 @@ void esp_hidd_prf_cb_hdl(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
         }
         case ESP_GATTS_DISCONNECT_EVT: {
 			 esp_hidd_cb_param_t cb_param = {0};
-			 memcpy(cb_param.disconnect.remote_bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
+			 memcpy(cb_param.disconnect.remote_bda, param->disconnect.remote_bda, sizeof(esp_bd_addr_t));
 			 if(hidd_le_env.hidd_cb != NULL) {
                     (hidd_le_env.hidd_cb)(ESP_HIDD_EVENT_BLE_DISCONNECT, &cb_param);
              }

--- a/main/hidd_le_prf_int.h
+++ b/main/hidd_le_prf_int.h
@@ -27,6 +27,8 @@
 //HID BLE profile log tag
 #define HID_LE_PRF_TAG                        "HID_LE_PRF"
 
+#define CHAR_DECLARATION_SIZE   (sizeof(uint8_t))
+
 /// Maximal number of HIDS that can be added in the DB
 #ifndef USE_ONE_HIDS_INSTANCE
 #define HIDD_LE_NB_HIDS_INST_MAX              (2)


### PR DESCRIPTION
* Found a bug in the HID callbacks -> BT-address was written to connect parameter instead of disconnect -> one byte shifted
* Added helper function to determine if there is at least one device connected
* HID reports are sent to ALL connected devices by default. If the `$SW <ble addr>` command is used, than the selected device gets the HID reports only
